### PR TITLE
Added package events to logistics peripherals

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/events/PackageEvent.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/events/PackageEvent.java
@@ -1,0 +1,17 @@
+
+package com.simibubi.create.compat.computercraft.events;
+
+import org.jetbrains.annotations.NotNull;
+import net.minecraft.world.item.ItemStack;
+
+public class PackageEvent implements ComputerEvent {
+
+	public @NotNull ItemStack box;
+	public String status;
+
+	public PackageEvent(@NotNull ItemStack box, String status) {
+		this.box = box;
+		this.status = status;
+	}
+
+}

--- a/src/main/java/com/simibubi/create/compat/computercraft/events/RepackageEvent.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/events/RepackageEvent.java
@@ -1,0 +1,17 @@
+
+package com.simibubi.create.compat.computercraft.events;
+
+import org.jetbrains.annotations.NotNull;
+import net.minecraft.world.item.ItemStack;
+
+public class RepackageEvent implements ComputerEvent {
+
+	public @NotNull ItemStack box;
+	public int count;
+
+	public RepackageEvent(@NotNull ItemStack box, int count) {
+		this.box = box;
+		this.count = count;
+	}
+
+}

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/FrogportPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/FrogportPeripheral.java
@@ -8,6 +8,9 @@ import com.simibubi.create.content.logistics.packagePort.PackagePortConfiguratio
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
 
+import com.simibubi.create.compat.computercraft.events.ComputerEvent;
+import com.simibubi.create.compat.computercraft.events.PackageEvent;
+import com.simibubi.create.compat.computercraft.implementation.luaObjects.PackageLuaObject;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
@@ -68,6 +71,13 @@ public class FrogportPeripheral extends SyncedPeripheral<FrogportBlockEntity> {
 	@LuaFunction(mainThread = true)
 	public Map<String, ?> getItemDetail(int slot) throws LuaException {
 		return ComputerUtil.getItemDetail(blockEntity.inventory, slot);
+	}
+
+	@Override
+	public void prepareComputerEvent(@NotNull ComputerEvent event) {
+		if (event instanceof PackageEvent pe) {
+			queueEvent(pe.status, new PackageLuaObject(null, pe.box));
+		}
 	}
 
 	@NotNull

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
@@ -12,6 +12,8 @@ import com.simibubi.create.compat.computercraft.implementation.luaObjects.Packag
 import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
 import com.simibubi.create.compat.computercraft.implementation.ComputerUtil;
 
+import com.simibubi.create.compat.computercraft.events.ComputerEvent;
+import com.simibubi.create.compat.computercraft.events.PackageEvent;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.lua.LuaException;
 
@@ -81,6 +83,13 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
 		if (box.isEmpty())
 			return null;
 		return new PackageLuaObject(blockEntity, box);
+	}
+
+	@Override
+	public void prepareComputerEvent(@NotNull ComputerEvent event) {
+		if (event instanceof PackageEvent pe) {
+			queueEvent(pe.status, new PackageLuaObject(blockEntity, pe.box));
+		}
 	}
 
 	@NotNull

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PostboxPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PostboxPeripheral.java
@@ -10,6 +10,9 @@ import dan200.computercraft.api.lua.LuaFunction;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.simibubi.create.compat.computercraft.events.ComputerEvent;
+import com.simibubi.create.compat.computercraft.events.PackageEvent;
+import com.simibubi.create.compat.computercraft.implementation.luaObjects.PackageLuaObject;
 import java.util.Map;
 
 public class PostboxPeripheral extends SyncedPeripheral<PostboxBlockEntity> {
@@ -68,6 +71,13 @@ public class PostboxPeripheral extends SyncedPeripheral<PostboxBlockEntity> {
 		}
 		throw new LuaException("Unknown configuration: \"" + config
 				+ "\" Possible configurations are: \"send_recieve\" and \"send\".");
+	}
+
+	@Override
+	public void prepareComputerEvent(@NotNull ComputerEvent event) {
+		if (event instanceof PackageEvent pe) {
+			queueEvent(pe.status, new PackageLuaObject(null, pe.box));
+		}
 	}
 
 	@NotNull

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RepackagerPeripheral.java
@@ -9,6 +9,9 @@ import com.simibubi.create.compat.computercraft.implementation.ComputerUtil;
 
 import dan200.computercraft.api.peripheral.IComputerAccess;
 
+import com.simibubi.create.compat.computercraft.events.ComputerEvent;
+import com.simibubi.create.compat.computercraft.events.RepackageEvent;
+import com.simibubi.create.compat.computercraft.events.PackageEvent;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.world.item.ItemStack;
@@ -82,6 +85,15 @@ public class RepackagerPeripheral extends SyncedPeripheral<RepackagerBlockEntity
 			return null;
 
 		return new PackageLuaObject(blockEntity, box);
+	}
+
+	@Override
+	public void prepareComputerEvent(@NotNull ComputerEvent event) {
+		if (event instanceof RepackageEvent pe) {
+			queueEvent("package_repackaged", new PackageLuaObject(blockEntity, pe.box), pe.count);
+		} else if (event instanceof PackageEvent pe) {
+			queueEvent(pe.status, new PackageLuaObject(blockEntity, pe.box));
+		}
 	}
 
 	@NotNull

--- a/src/main/java/com/simibubi/create/content/logistics/packagePort/frogport/FrogportBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagePort/frogport/FrogportBlockEntity.java
@@ -7,6 +7,7 @@ import com.simibubi.create.AllItems;
 import com.simibubi.create.api.equipment.goggles.IHaveHoveringInformation;
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
+import com.simibubi.create.compat.computercraft.events.PackageEvent;
 import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.box.PackageStyles;
 import com.simibubi.create.content.logistics.packagePort.PackagePortBlockEntity;
@@ -171,6 +172,8 @@ public class FrogportBlockEntity extends PackagePortBlockEntity implements IHave
 					if (target == null
 						|| !target.depositImmediately() && !target.export(level, worldPosition, animatedPackage, false))
 						drop(animatedPackage);
+					else
+						computerBehaviour.prepareComputerEvent(new PackageEvent(animatedPackage, "package_sent"));
 					animatedPackage = null;
 				}
 			} else {
@@ -198,6 +201,8 @@ public class FrogportBlockEntity extends PackagePortBlockEntity implements IHave
 			if (!ItemHandlerHelper.insertItem(inventory, animatedPackage.copy(), false)
 				.isEmpty())
 				drop(animatedPackage);
+			else
+				computerBehaviour.prepareComputerEvent(new PackageEvent(animatedPackage, "package_received"));
 		}
 
 		animatedPackage = null;

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -14,6 +14,7 @@ import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.Create;
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
+import com.simibubi.create.compat.computercraft.events.PackageEvent;
 import com.simibubi.create.api.packager.unpacking.UnpackingHandler;
 import com.simibubi.create.content.contraptions.actors.psi.PortableStorageInterfaceBlockEntity;
 import com.simibubi.create.content.logistics.BigItemStack;
@@ -362,6 +363,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		boolean unpacked = toUse.unpack(level, target, targetState, facing, items, orderContext, simulate);
 
 		if (unpacked && !simulate) {
+			computerBehaviour.prepareComputerEvent(new PackageEvent(box, "package_received"));
 			previouslyUnwrapped = box;
 			animationInward = true;
 			animationTicks = CYCLE;
@@ -483,6 +485,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 
 		ItemStack createdBox =
 			extractedPackageItem.isEmpty() ? PackageItem.containing(extractedItems) : extractedPackageItem.copy();
+		computerBehaviour.prepareComputerEvent(new PackageEvent(createdBox, "package_created"));
 		PackageItem.clearAddress(createdBox);
 
 		if (fixedAddress != null)

--- a/src/main/java/com/simibubi/create/content/logistics/packager/repackager/RepackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/repackager/RepackagerBlockEntity.java
@@ -9,6 +9,8 @@ import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
 import com.simibubi.create.content.logistics.packager.PackagerItemHandler;
 import com.simibubi.create.content.logistics.packager.PackagingRequest;
 
+import com.simibubi.create.compat.computercraft.events.RepackageEvent;
+import com.simibubi.create.compat.computercraft.events.PackageEvent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -48,6 +50,7 @@ public class RepackagerBlockEntity extends PackagerBlockEntity {
 		if (simulate)
 			return true;
 
+		computerBehaviour.prepareComputerEvent(new PackageEvent(box, "package_received"));
 		previouslyUnwrapped = box;
 		animationInward = true;
 		animationTicks = CYCLE;
@@ -123,6 +126,11 @@ public class RepackagerBlockEntity extends PackagerBlockEntity {
 		if (boxesToExport.isEmpty())
 			return;
 
+		if (computerBehaviour.hasAttachedComputer()) {
+			for (BigItemStack box : boxesToExport) {
+				computerBehaviour.prepareComputerEvent(new RepackageEvent(box.stack, box.count));
+			}
+		}
 		queuedExitingPackages.addAll(boxesToExport);
 		notifyUpdate();
 	}

--- a/src/main/java/com/simibubi/create/content/trains/station/GlobalStation.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/GlobalStation.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.packagePort.postbox.PostboxBlockEntity;
+import com.simibubi.create.compat.computercraft.events.PackageEvent;
 import com.simibubi.create.content.trains.entity.Carriage;
 import com.simibubi.create.content.trains.entity.Train;
 import com.simibubi.create.content.trains.graph.DimensionPalette;
@@ -195,6 +196,8 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 						continue;
 
 					ItemStack result = ItemHandlerHelper.insertItemStacked(carriageInventory, stack, false);
+					if (box != null)
+						box.computerBehaviour.prepareComputerEvent(new PackageEvent(stack, "package_sent"));
 					if (!result.isEmpty())
 						continue;
 
@@ -232,6 +235,8 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 					}
 
 					ItemStack result = ItemHandlerHelper.insertItemStacked(postboxInventory, stack, false);
+					if (box != null)
+						box.computerBehaviour.prepareComputerEvent(new PackageEvent(stack, "package_received"));
 					if (!result.isEmpty())
 						continue;
 


### PR DESCRIPTION
Packager:
`package_created` - when the packager makes a package, return the package object
`package_received`- when the packager receieves a package, returns the package object

Repackager:
`package_repackaged` - when the repackager repackages, returns the package object and count (number)
`package_received` - when the repackager receives a package, returns the package object


Forgport:
`package_sent` - when the forgport sends a package on the chain conveyor, returns the package object
`package_recieved` - when the forgport recieves a package from the chain conveyor, returns the package object

Postbox:
`package_sent` - when the forgport sends a package onto a train, returns the package object
`package_recieved` - when the forgport recieves a package from a train, returns the package object